### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install --save-dev crypto-xor
 ## Example use
 
 ```javascript
-var crypto-xor = require('crypto-xor');
+var cryptoXor = require('crypto-xor');
 
 var symmetricKey = '5_Gk>V!q9umG-dx4GK*V;j!_';
 


### PR DESCRIPTION
Wrong module name in the example.
var crypto-xor = require('crypto-xor') to var cryptoXor = require('crypto-xor');